### PR TITLE
Changes ApplicationAlias reported in --help

### DIFF
--- a/src/PackageOptions.cs
+++ b/src/PackageOptions.cs
@@ -52,7 +52,7 @@ namespace NugetUtility
         [Option('p', "print", Default = true, HelpText = "Print licenses.")]
         public bool? Print { get; set; }
 
-        [Usage(ApplicationAlias = "dotnet-nuget")]
+        [Usage(ApplicationAlias = "dotnet-project-licenses")]
         public static IEnumerable<Example> Examples
         {
             get


### PR DESCRIPTION
Was `dotnet-nuget` and is now `dotnet-project-licenses` as the tool is installed with this name.